### PR TITLE
Signal receiver that creates UserProfile when User created (fixes #494)

### DIFF
--- a/apps/volontulo/__init__.py
+++ b/apps/volontulo/__init__.py
@@ -3,3 +3,5 @@
 """
 .. module:: __init__
 """
+
+default_app_config = 'apps.volontulo.apps.VolontuloAppConfig'

--- a/apps/volontulo/apps.py
+++ b/apps/volontulo/apps.py
@@ -1,0 +1,8 @@
+from django.apps import AppConfig
+
+
+class VolontuloAppConfig(AppConfig):
+    name = 'apps.volontulo'
+
+    def ready(self):
+        from . import signals

--- a/apps/volontulo/apps.py
+++ b/apps/volontulo/apps.py
@@ -1,8 +1,14 @@
+"""
+.. module:: apps
+"""
+
 from django.apps import AppConfig
 
 
 class VolontuloAppConfig(AppConfig):
+    """Configuration for volontulo app."""
     name = 'apps.volontulo'
 
     def ready(self):
+        # pylint: disable=unused-variable
         from . import signals

--- a/apps/volontulo/signals.py
+++ b/apps/volontulo/signals.py
@@ -1,0 +1,11 @@
+from django.contrib.auth.models import User
+from django.db.models.signals import post_save
+from django.dispatch import receiver
+
+from .models import UserProfile
+
+
+@receiver(post_save, sender=User)
+def create_profile(sender, instance, created, **kwargs):
+    if created:
+        UserProfile.objects.get_or_create(user=instance)

--- a/apps/volontulo/signals.py
+++ b/apps/volontulo/signals.py
@@ -1,3 +1,7 @@
+"""
+.. module:: signals
+"""
+
 from django.contrib.auth.models import User
 from django.db.models.signals import post_save
 from django.dispatch import receiver
@@ -7,5 +11,10 @@ from .models import UserProfile
 
 @receiver(post_save, sender=User)
 def create_profile(sender, instance, created, **kwargs):
+    """
+    Create apps.volontulo.models.UserProfile object
+    when django.contrib.auth.models.User object screated.
+    """
+    # pylint: disable=unused-argument
     if created:
         UserProfile.objects.get_or_create(user=instance)

--- a/apps/volontulo/signals.py
+++ b/apps/volontulo/signals.py
@@ -13,7 +13,7 @@ from .models import UserProfile
 def create_profile(sender, instance, created, **kwargs):
     """
     Create apps.volontulo.models.UserProfile object
-    when django.contrib.auth.models.User object screated.
+    when django.contrib.auth.models.User object created.
     """
     # pylint: disable=unused-argument
     if created:

--- a/apps/volontulo/tests/common.py
+++ b/apps/volontulo/tests/common.py
@@ -8,7 +8,7 @@ from django.contrib.auth.models import User
 
 from apps.volontulo.models import Offer
 from apps.volontulo.models import Organization
-from apps.volontulo.models import UserProfile
+
 
 COMMON_OFFER_DATA = {
     'organization': None,
@@ -32,7 +32,7 @@ def initialize_empty_volunteer():
         last_name=u'Brzęczyszczykiewicz',
     )
     volunteer_user1.save()
-    userprofile = UserProfile.objects.create(user=volunteer_user1)
+    userprofile = volunteer_user1.userprofile
     userprofile.phone_no = '333666999'
     userprofile.save()
     return volunteer_user1
@@ -54,9 +54,7 @@ def initialize_empty_organization():
         last_name=u'Organization1Lastname',
     )
     organization_user1.save()
-    organization_profile1 = UserProfile.objects.create(
-        user=organization_user1,
-    )
+    organization_profile1 = organization_user1.userprofile
     organization_profile1.organizations.add(organization1)
     return organization1
 
@@ -70,7 +68,6 @@ def initialize_filled_volunteer_and_organization():
         'volunteer2'
     )
     volunteer_user2.save()
-    UserProfile.objects.create(user=volunteer_user2)
 
     # create organization user to create offers
     organization2 = Organization.objects.create(name=u'Organization 2')
@@ -82,9 +79,7 @@ def initialize_filled_volunteer_and_organization():
         'organization2'
     )
     organization_user2.save()
-    organization_profile2 = UserProfile.objects.create(
-        user=organization_user2,
-    )
+    organization_profile2 = organization_user2.userprofile
     organization_profile2.organizations.add(organization2)
 
     # create organization offers and assign volunteer to them
@@ -147,9 +142,7 @@ def initialize_empty_organizations():
             'organization{}'.format(i)
         )
         organization_user.save()
-        user_profile = UserProfile.objects.create(
-            user=organization_user,
-        )
+        user_profile = organization_user.userprofile
         user_profile.organizations.add(organization)
 
 
@@ -164,7 +157,7 @@ def initialize_administrator(
     """
     administrator1 = User.objects.create_user(username, email, password)
     administrator1.save()
-    administrator_profile = UserProfile.objects.create(user=administrator1)
+    administrator_profile = administrator1.userprofile
     administrator_profile.is_administrator = True
     administrator_profile.save()
     return administrator1

--- a/apps/volontulo/tests/models/test_userprofile.py
+++ b/apps/volontulo/tests/models/test_userprofile.py
@@ -8,7 +8,6 @@ from django.test import TestCase
 
 from apps.volontulo.models import Organization
 from apps.volontulo.models import User
-from apps.volontulo.models import UserProfile
 
 
 class TestUserProfile(TestCase):
@@ -18,37 +17,38 @@ class TestUserProfile(TestCase):
         u"""Set up each test."""
 
         # volunteer user
-        self.volunteer_user = UserProfile.objects.create(
-            user=User.objects.create_user(
-                username='volunteer@example.com',
-                email='volunteer@example.com',
-                password='volunteer',
-            ),
-            is_administrator=False,
+        user = User.objects.create_user(
+            username='volunteer@example.com',
+            email='volunteer@example.com',
+            password='volunteer',
         )
+        self.volunteer_user = user.userprofile
+        self.volunteer_user.is_administrator = False
+        self.volunteer_user.save()
 
         # organization user
-        self.organization_user = UserProfile.objects.create(
-            user=User.objects.create_user(
-                username='organization@example.com',
-                email='organization@example.com',
-                password='organization',
-            ),
-            is_administrator=False,
+        user = User.objects.create_user(
+            username='organization@example.com',
+            email='organization@example.com',
+            password='organization',
         )
+        self.organization_user = user.userprofile
+        self.organization_user.is_administrator = False
+        self.organization_user.save()
+
         self.organization_user.organizations.add(
             Organization.objects.create(name=u'Organization')
         )
 
         # administrator user
-        self.administrator_user = UserProfile.objects.create(
-            user=User.objects.create_user(
-                username='administrator@example.com',
-                email='administrator@example.com',
-                password='administrator',
-            ),
-            is_administrator=True
+        user = User.objects.create_user(
+            username='administrator@example.com',
+            email='administrator@example.com',
+            password='administrator',
         )
+        self.administrator_user = user.userprofile
+        self.administrator_user.is_administrator = True
+        self.administrator_user.save()
 
     def test__string_reprezentation(self):
         u"""String reprezentation of an userprofile object."""

--- a/apps/volontulo/tests/views/offers/commons.py
+++ b/apps/volontulo/tests/views/offers/commons.py
@@ -8,7 +8,6 @@ from django.contrib.auth.models import User
 
 from apps.volontulo.models import Offer
 from apps.volontulo.models import Organization
-from apps.volontulo.models import UserProfile
 
 
 class TestOffersCommons(object):
@@ -57,8 +56,7 @@ class TestOffersCommons(object):
             '123volunteer'
         )
 
-        cls.volunteer = UserProfile(user=volunteer_user)
-        cls.volunteer.save()
+        cls.volunteer = volunteer_user.userprofile
 
         organization_user = User.objects.create_user(
             'cls.organization@example.com',
@@ -66,10 +64,7 @@ class TestOffersCommons(object):
             '123org'
         )
 
-        cls.organization_profile = UserProfile(
-            user=organization_user,
-        )
-        cls.organization_profile.save()
+        cls.organization_profile = organization_user.userprofile
         cls.organization_profile.organizations.add(cls.organization)
 
         admin_user = User.objects.create_user(
@@ -78,8 +73,6 @@ class TestOffersCommons(object):
             '123admin'
         )
 
-        cls.admin = UserProfile(
-            user=admin_user,
-            is_administrator=True,
-        )
+        cls.admin = admin_user.userprofile
+        cls.admin.is_administrator = True
         cls.admin.save()

--- a/apps/volontulo/tests/views/offers/test_offer_create.py
+++ b/apps/volontulo/tests/views/offers/test_offer_create.py
@@ -10,7 +10,6 @@ from django.test import TestCase
 
 from apps.volontulo.models import Offer
 from apps.volontulo.models import Organization
-from apps.volontulo.models import UserProfile
 
 
 class TestOffersCreate(TestCase):
@@ -31,19 +30,13 @@ class TestOffersCreate(TestCase):
             '123org'
         )
         organization_user.save()
-        cls.organization_profile = UserProfile(
-            user=organization_user,
-        )
-        cls.organization_profile.save()
+        cls.organization_profile = organization_user.userprofile
         cls.organization_profile.organizations.add(cls.organization)
 
-        no_org_user = User.objects.create_user(
+        User.objects.create_user(
             'no_organ@example.com',
             'no_organ@example.com',
             '123no_org'
-        )
-        UserProfile.objects.create(
-            user=no_org_user,
         )
 
     def setUp(self):

--- a/apps/volontulo/tests/views/offers/test_offer_edit.py
+++ b/apps/volontulo/tests/views/offers/test_offer_edit.py
@@ -10,7 +10,6 @@ from django.test import TestCase
 
 from apps.volontulo.models import Offer
 from apps.volontulo.models import Organization
-from apps.volontulo.models import UserProfile
 
 
 class TestOffersEdit(TestCase):
@@ -33,10 +32,7 @@ class TestOffersEdit(TestCase):
             cls.organization_user_password
         )
         organization_user.save()
-        cls.organization_profile = UserProfile(
-            user=organization_user
-        )
-        cls.organization_profile.save()
+        cls.organization_profile = organization_user.userprofile
         cls.organization_profile.organizations.add(cls.organization)
         cls.offer = Offer.objects.create(
             organization=cls.organization,

--- a/apps/volontulo/tests/views/offers/test_offer_join.py
+++ b/apps/volontulo/tests/views/offers/test_offer_join.py
@@ -10,7 +10,6 @@ from django.test import TestCase
 
 from apps.volontulo.models import Offer
 from apps.volontulo.models import Organization
-from apps.volontulo.models import UserProfile
 
 
 class TestOffersJoin(TestCase):
@@ -47,8 +46,7 @@ class TestOffersJoin(TestCase):
             'vol123',
         )
         cls.volunteer.save()
-        cls.volunteer_profile = UserProfile(user=cls.volunteer)
-        cls.volunteer_profile.save()
+        cls.volunteer_profile = cls.volunteer.userprofile
 
     def setUp(self):
         """Set up each test."""

--- a/apps/volontulo/tests/views/offers/test_offer_view.py
+++ b/apps/volontulo/tests/views/offers/test_offer_view.py
@@ -58,7 +58,8 @@ class TestOffersView(TestCase):
         ) for i in range(10)]
         for i in range(10):
             volunteers[i].save()
-        cls.volunteers_profiles = [volunteer.userprofile for volunteer in volunteers]
+        cls.volunteers_profiles = [
+            volunteer.userprofile for volunteer in volunteers]
         for i in range(0, 10, 2):
             cls.offer.volunteers.add(cls.volunteers_profiles[i].user)
 

--- a/apps/volontulo/tests/views/offers/test_offer_view.py
+++ b/apps/volontulo/tests/views/offers/test_offer_view.py
@@ -10,7 +10,6 @@ from django.test import TestCase
 
 from apps.volontulo.models import Offer
 from apps.volontulo.models import Organization
-from apps.volontulo.models import UserProfile
 
 
 class TestOffersView(TestCase):
@@ -31,10 +30,8 @@ class TestOffersView(TestCase):
             '123admin'
         )
         administrator.save()
-        cls.administrator_profile = UserProfile(
-            user=administrator,
-            is_administrator=True,
-        )
+        cls.administrator_profile = administrator.userprofile
+        cls.administrator_profile.is_administrator = True
         cls.administrator_profile.save()
         cls.offer = Offer.objects.create(
             organization=organization,
@@ -61,11 +58,7 @@ class TestOffersView(TestCase):
         ) for i in range(10)]
         for i in range(10):
             volunteers[i].save()
-        cls.volunteers_profiles = [
-            UserProfile(user=volunteers[i]) for i in range(10)
-        ]
-        for i in range(10):
-            cls.volunteers_profiles[i].save()
+        cls.volunteers_profiles = [volunteer.userprofile for volunteer in volunteers]
         for i in range(0, 10, 2):
             cls.offer.volunteers.add(cls.volunteers_profiles[i].user)
 

--- a/apps/volontulo/tests/views/offers/test_offers_archived.py
+++ b/apps/volontulo/tests/views/offers/test_offers_archived.py
@@ -10,7 +10,6 @@ from django.test import TestCase
 
 from apps.volontulo.models import Offer
 from apps.volontulo.models import Organization
-from apps.volontulo.models import UserProfile
 
 
 class TestOffersArchived(TestCase):
@@ -34,8 +33,7 @@ class TestOffersArchived(TestCase):
                     'volunteer{0}{1}@example.com'.format(idx + 1, i),
                     'password',
                 )
-                userprofile = UserProfile(user=user)
-                userprofile.save()
+                userprofile = user.userprofile
                 userprofile.organizations.add(org)
                 userprofile.save()
 

--- a/apps/volontulo/tests/views/test_superuser.py
+++ b/apps/volontulo/tests/views/test_superuser.py
@@ -1,0 +1,63 @@
+from django.contrib.auth.models import User
+from django.test import Client
+from django.test import TestCase
+
+
+class TestUserCreatedWithManagePyCreatesuperuser(TestCase):
+    """Check if user created with manage.py createsuperuser can log in and see own profile."""
+    @classmethod
+    def setUpTestData(cls):
+        cls.superuser_data = {
+            'username': 'test_admin',
+            'password': 'secret',
+            'email': 'test_admin@example.com'
+        }
+        User.objects.create_superuser(**cls.superuser_data)
+
+    def setUp(self):
+        self.client = Client()
+
+    def test_log_into_admin_panel(self):
+        """Check if user can log into admin panel."""
+        response = self.client.post(
+            '/admin/login/',
+            {
+                'username': self.superuser_data['username'],
+                'password': self.superuser_data['password'],
+                'next': '/admin/login/',
+            },
+            follow=True,
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'Wyloguj się')
+
+    def test_failed_log_into_admin_panel(self):
+        """Check if user can log into admin panel using invalid credentials."""
+        response = self.client.post(
+            '/admin/login/',
+            {
+                'username': self.superuser_data['username'],
+                'password': self.superuser_data['password'] + 'invalid',
+                'next': '/admin/login/',
+            },
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(
+            response,
+            'Wprowadź poprawne dane w polach &quot;użytkownik&quot;'
+            ' i &quot;hasło&quot; dla konta należącego do zespołu.'
+            ' Uwaga: wielkość liter może mieć znaczenie.',
+        )
+
+    def test_log_into_admin_panel_and_go_to_logged_user_profile_view(self):
+        """Check if user can log into admin panel and then see own profile page (logged_user_profile view)."""
+        self.client.post(
+            '/admin/login/',
+            {
+                'username': self.superuser_data['username'],
+                'password': self.superuser_data['password'],
+                'next': '/admin/login/',
+            },
+        )
+        response = self.client.get('/me')
+        self.assertEqual(response.status_code, 200)

--- a/apps/volontulo/tests/views/test_superuser.py
+++ b/apps/volontulo/tests/views/test_superuser.py
@@ -1,10 +1,17 @@
+"""
+.. module:: test_superuser
+"""
+
 from django.contrib.auth.models import User
 from django.test import Client
 from django.test import TestCase
 
 
 class TestUserCreatedWithManagePyCreatesuperuser(TestCase):
-    """Check if user created with manage.py createsuperuser can log in and see own profile."""
+    """
+    Check if user created with "manage.py createsuperuser"
+    can log in and see own profile.
+    """
     @classmethod
     def setUpTestData(cls):
         cls.superuser_data = {
@@ -50,7 +57,10 @@ class TestUserCreatedWithManagePyCreatesuperuser(TestCase):
         )
 
     def test_log_into_admin_panel_and_go_to_logged_user_profile_view(self):
-        """Check if user can log into admin panel and then see own profile page (logged_user_profile view)."""
+        """
+        Check if user can log into admin panel and then see
+        own profile page (logged_user_profile view).
+        """
         self.client.post(
             '/admin/login/',
             {

--- a/apps/volontulo/views/auth.py
+++ b/apps/volontulo/views/auth.py
@@ -144,9 +144,8 @@ class Register(View):
             )
             user.is_active = False
             user.save()
-            profile = UserProfile(user=user)
+            profile = user.userprofile
             ctx['uuid'] = profile.uuid
-            profile.save()
         except IntegrityError:
             # if attempt failed, because user already exists we need show
             # error message:


### PR DESCRIPTION
__Story / Bug id:__ https://github.com/CodeForPoznan/volontulo/issues/494

__Reference person:__ @JarUrb

__Description:__

When user is created using `manage.py createsuperuser`, user's profile isn't created. It can lead to internal server errors (HTTP 500).

In commit 2bdb371437d121d73739b981f39b1906c6377606 I added test to show that case. That test would fail without changes in commit bb924b50fffe51093e1ae87cfbf84894539d0797. I also had to fix other tests in commit 1e5d85ced5ccf056874d85f98e961fe4f7cd3f73.

I know that some people don't like signals, but without this change we would have to deal with inconsistent data (i.e. user without corresponding UserProfile) or solve the problem another way (e.g. by subclassing Django's User model and overriding `save()` method) or forbid using `manage.py createsuperuser` entirely.