### PR TITLE
Allow "admin@volontuloapp.org" user to log into admin panel as site administrator (fixes #493)

### DIFF
--- a/initial/data.json
+++ b/initial/data.json
@@ -3,7 +3,7 @@
     "pk": 1,
     "model": "auth.user",
     "fields": {
-        "is_staff": false,
+        "is_staff": true,
         "email": "admin@volontuloapp.org",
         "first_name": "",
         "groups": [],
@@ -11,7 +11,7 @@
         "last_login": "2016-02-25T11:47:59.562Z",
         "last_name": "",
         "username": "admin@volontuloapp.org",
-        "is_superuser": false,
+        "is_superuser": true,
         "is_active": true,
         "date_joined": "2016-02-05T09:34:43.382Z",
         "user_permissions": []


### PR DESCRIPTION
__Story / Bug id:__ https://github.com/CodeForPoznan/volontulo/issues/493
__Reference person:__ @JarUrb
__Description:__ User `admin@volontuloapp.org` from initial data should be able to log into admin panel as site administrator. It is important especially during development.