### PR TITLE
Update of badges that will direct them to new organization

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # volontulo
 
-[![Join the chat at https://gitter.im/stxnext-csr/volontulo](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/stxnext-csr/volontulo?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
-[![Build Status](https://travis-ci.org/stxnext-csr/volontulo.svg)](https://travis-ci.org/stxnext-csr/volontulo)
-[![codecov.io](http://codecov.io/github/stxnext-csr/volontulo/coverage.svg?branch=master)](http://codecov.io/github/stxnext-csr/volontulo?branch=master)
+[![Join the chat at https://gitter.im/CodeForPoznan/volontulo](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/CodeForPoznan/volontulo?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![Build Status](https://travis-ci.org/CodeForPoznan/volontulo.svg)](https://travis-ci.org/CodeForPoznan/volontulo)
+[![codecov.io](http://codecov.io/github/CodeForPoznan/volontulo/coverage.svg?branch=master)](http://codecov.io/github/CodeForPoznan/volontulo?branch=master)
 
 ![Volontulo logo](/apps/volontulo/frontend/img/volo_logo.png)
 


### PR DESCRIPTION
__Story / Bug id:__ N/A
__Reference person:__ @magul
__Description:__
Bacause me moved volontulo to new organization on Github we are also changin place, where we chat about (gitter), test (travis) and store coverage information (codecov) about volontulo.

__New imports / dependencies:__

* N/A

__Unit Tests:__

* N/A

__What tests do I need to run to validate this change:__

Check if badges are pointing to proper locations and have correct values.