### PR TITLE
Recreate local_config.yaml during running container

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,6 +1,14 @@
 #!/bin/bash
 set -e
 
+# we need to re-create local_config.yaml during cration of container, because
+# mounted volume overwrite all files available during build phase:
+if [ ! -f local_config.yaml ]; then
+    cp etc/local_config.yaml.sample local_config.yaml;
+    sed '/^secret_key/ d' local_config.yaml > tmp.yaml && mv tmp.yaml local_config.yaml;
+    echo "secret_key: $SECRET_KEY" >> local_config.yaml;
+fi
+
 wait-for-it db:5432
 
 python3 manage.py migrate --settings=volontulo_org.settings.dev_docker


### PR DESCRIPTION
__Story / Bug id:__ N/A
__Reference person:__ @magul
__Description:__

Recreate `local_config.yaml` during run phase in from `docker-compse` as there is volume mounted and it overwrite `local_config.yaml` created during build phase.

__New imports / dependencies:__

* N/A

__Unit Tests:__

* N/A

__What tests do I need to run to validate this change:__

* Clone fresh repository (check if it doesn't contain `local_config.yaml`)
* Build docker-based environment and check that it works properly