### PR TITLE
No <img> placeholder on offer pages when image is missing

### DIFF
--- a/apps/volontulo/templates/offers/offer_apply.html
+++ b/apps/volontulo/templates/offers/offer_apply.html
@@ -6,7 +6,9 @@
 
 {% block content-heading %}
 <div class="heading-wrapper">
-    <img class="img-responsive center-block" src="{{ MEDIA_URL }}{{ main_image|default:'' }}" alt="{{ offer.title|safe }}" />
+    {% if main_image %}
+        <img class="img-responsive center-block" src="{{ MEDIA_URL }}{{ main_image }}" alt="{{ offer.title|safe }}" />
+    {% endif %}
     {% if user.is_administrator %}
         <a href="{% url 'offers_edit' offer.title|slugify offer.id %}" class="btn btn-primary">Edytuj ofertę</a>
     {% endif %}

--- a/apps/volontulo/templates/offers/show_offer.html
+++ b/apps/volontulo/templates/offers/show_offer.html
@@ -7,7 +7,9 @@
 
 {% block content-heading %}
 <div class="heading-wrapper">
-    <img class="img-responsive center-block" src="{{ MEDIA_URL }}{{ main_image|default:'' }}" alt="{{ offer.title|safe }}" />
+    {% if main_image %}
+        <img class="img-responsive center-block" src="{{ MEDIA_URL }}{{ main_image }}" alt="{{ offer.title|safe }}" />
+    {% endif %}
     <div class="panels">
         <div class="offer-title">
             <h2 class="title">{{ offer.title }}</h2>


### PR DESCRIPTION
__Description:__

Don't include `<img>` tag in offers' pages, when images is missing in offer.

__What tests do I need to run to validate this change:__

Create offer without main image and see that there is no empty placeholder in offer page (details and join pages were affected).