### PR TITLE
#570 Docker secret key env

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ backend:
   image: codeforpoznan/volontulo
   # build: .
   environment:
-    - SECRET_KEY=a63eb5ef-3b25-4595-846a-5d97d99486f0
+    SECRET_KEY: a63eb5ef-3b25-4595-846a-5d97d99486f0
   entrypoint: bash docker-entrypoint.sh
   # entrypoint: tail -f /dev/null
   working_dir: /volontulo/backend

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,8 @@ frontend:
 backend:
   image: codeforpoznan/volontulo
   # build: .
+  environment:
+    - SECRET_KEY=a63eb5ef-3b25-4595-846a-5d97d99486f0
   entrypoint: bash docker-entrypoint.sh
   # entrypoint: tail -f /dev/null
   working_dir: /volontulo/backend


### PR DESCRIPTION
Description:

Missing $SECRET_KEY prevents volontulo_backend

Current behaviour:

echo $SECRET_KEY returns empty string

Expected behaviour:

echo $SECRET_KEY returns secret key