### PR TITLE
Decide which packages we will use for fixtures generation #693

### DIFF
--- a/backend/requirements/base.txt
+++ b/backend/requirements/base.txt
@@ -6,7 +6,6 @@ Pillow==4.2.1
 six==1.11.0
 unipath==1.1
 wheel==0.30.0
-django-dynamic-fixture==1.9.5
 psycopg2==2.7.3.1
 djangorestframework==3.6.4
 djangorestframework-camel-case==1.0b1


### PR DESCRIPTION
__Description:__

I removed django-dynamic-fixture==1.9.5  from backend/requirements/base.txt 
I left in backend/requirements/dev.txt Faker==0.8.4 (Factory Boy already ships with integration with Faker)

