### PR TITLE
821 # editorconfig file added

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,24 @@
+# Editor configuration, see http://editorconfig.org
+root = true
+
+[*]
+charset = utf-8
+indent_style = space
+indent_size = 2
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+max_line_length = off
+trim_trailing_whitespace = false
+
+[Makefile]
+indent_style = tab
+
+[*.py]
+max_line_length = 79
+indent_size = 4
+
+# The JSON files contain newlines inconsistently
+[*.json]
+insert_final_newline = ignore


### PR DESCRIPTION
__Description:__

Editorconfig added. The reason is to enable consistent linting across IDEs / editors that support editorconfig

__New imports / dependencies:__
None

__Unit Tests:__
None

__What tests do I need to run to validate this change:__
None
