### PR TITLE
[RFC] removed dev CORS in favour of angular dev server proxy

### DIFF
--- a/backend/requirements/dev.txt
+++ b/backend/requirements/dev.txt
@@ -4,7 +4,6 @@ colorama==0.3.9
 django-coverage==1.2.4
 django-debug-toolbar==1.8
 django-extensions==1.9.1
-django-cors-headers==2.1.0
 factory-boy==2.9.2
 ipdb==0.10.3
 pdbpp==0.9.1

--- a/backend/volontulo_org/settings/dev.py
+++ b/backend/volontulo_org/settings/dev.py
@@ -18,12 +18,10 @@ INSTALLED_APPS += (
     'django_coverage',
     'django_extensions',
     'django_nose',
-    'corsheaders',
 )
 
 MIDDLEWARE_CLASSES += (
     'debug_toolbar.middleware.DebugToolbarMiddleware',
-    'corsheaders.middleware.CorsMiddleware',
 )
 
 TEST_RUNNER = 'django_nose.NoseTestSuiteRunner'
@@ -32,11 +30,6 @@ EMAIL_BACKEND = 'django.core.mail.backends.filebased.EmailBackend'
 EMAIL_FILE_PATH = os.path.join(BASE_DIR, 'fake_emails')
 
 ANGULAR_ROOT = 'http://localhost:4200'
-
-CORS_ORIGIN_WHITELIST = (
-    'localhost:4200',
-)
-CORS_ALLOW_CREDENTIALS = True
 
 SYSTEM_DOMAIN = 'localhost'
 

--- a/frontend/docker-dev-proxy.json
+++ b/frontend/docker-dev-proxy.json
@@ -1,0 +1,17 @@
+{
+  "/api/*": {
+    "target": "http://backend:8000",
+    "secure": false,
+    "logLevel": "debug"
+  },
+  "/static/*": {
+    "target": "http://backend:8000",
+    "secure": false,
+    "logLevel": "error"
+  },
+  "/media/*": {
+    "target": "http://backend:8000",
+    "secure": false,
+    "logLevel": "error"
+  }
+}

--- a/frontend/docker-entrypoint.sh
+++ b/frontend/docker-entrypoint.sh
@@ -2,4 +2,5 @@
 set -e
 
 npm install
-node_modules/.bin/ng serve --open --host=0.0.0.0
+node_modules/.bin/ng serve --open --host=0.0.0.0 --proxy docker-dev-proxy.json
+

--- a/frontend/src/environments/environment.ts
+++ b/frontend/src/environments/environment.ts
@@ -4,7 +4,7 @@
 // The list of which env maps to which file can be found in `.angular-cli.json`.
 
 export const environment = {
-  apiRoot: 'http://localhost:8000/api',
+  apiRoot: 'http://localhost:4200/api',
   djangoRoot: 'http://localhost:8000/o',
   production: false,
   sentryDSN: null,


### PR DESCRIPTION
__Description:__

This PR removes CORS support from Django. Since we only need CORS for development (as in "production" both backend and frontend will be served on the same domain), angular dev server proxy can be used instead.

The benefits are:
* one dependency less
* maybe a tiny bit more of security (no CORS)
* dev env will be a more similar to the prod ones (currently one with CORS, the others without)
* less havoc with CORS in dev mode (see i.e. https://github.com/CodeForPoznan/volontulo/pull/831).

__New imports / dependencies:__

No new dependencies. `django-cors-headers` removed.

__Unit Tests:__

Not relevant.

__What tests do I need to run to validate this change:__

Just run it locally, see if all the requests from the browser pass properly to the backend, see if server side rendering is not broken (but it's not used in dev, so it should not be relevant).

This PR has been prepared in a bit "quick" mode, so please test it ;). It looks like it works fine for me, though.