### PR TITLE
SCSS campaign: Refactor Banner SCSS

### DIFF
--- a/frontend/src/app/banner/banner.component.html
+++ b/frontend/src/app/banner/banner.component.html
@@ -1,1 +1,1 @@
-<img class="img-responsive img-center" src="assets/img/banner/volontulo_baner.png" alt="Volontulo Baner">
+<img class="img-responsive" src="assets/img/banner/volontulo_baner.png" alt="Volontulo Baner">

--- a/frontend/src/app/banner/banner.component.scss
+++ b/frontend/src/app/banner/banner.component.scss
@@ -1,3 +1,0 @@
-.img-center {
-  margin: 0 auto;
-}

--- a/frontend/src/app/banner/banner.component.ts
+++ b/frontend/src/app/banner/banner.component.ts
@@ -2,7 +2,6 @@ import { Component } from '@angular/core';
 
 @Component({
   selector: 'volontulo-banner',
-  templateUrl: './banner.component.html',
-  styleUrls: ['./banner.component.scss']
+  templateUrl: './banner.component.html'
 })
 export class BannerComponent { }


### PR DESCRIPTION
__Description:__

SCSS campaign: Removed banner styles. We don't need them, because there is no way, that image won't fill whole page width. We can add some classes if we change the banner, but we'll worry when the time comes.
