### PR TITLE
Fix how we filter active offers using started_at and finished_at fields

### DIFF
--- a/backend/apps/volontulo/models.py
+++ b/backend/apps/volontulo/models.py
@@ -49,7 +49,7 @@ class OffersManager(models.Manager):
         """Return active offers."""
         return self.filter(
             # that covers action_status__in=('ongoing', 'future'):
-            Q(started_at__isnull=True) | Q(started_at__lte=timezone.now()),
+            Q(finished_at__isnull=True) | Q(finished_at__gte=timezone.now()),
             offer_status='published',
             recruitment_status__in=('open', 'supplemental'),
         ).all()

--- a/backend/apps/volontulo/tests/common.py
+++ b/backend/apps/volontulo/tests/common.py
@@ -71,13 +71,13 @@ def initialize_filled_volunteer_and_organization():
 def test_offer_list_fields(self, offer):
     """Test read's fields of offers REST API endpoint."""
     self.assertIsInstance(offer.pop('action_status'), str)
-    self.assertIsInstance(offer.pop('finished_at'), str)
+    self.assertIsInstance(offer.pop('finished_at'), (str, type(None)))
     self.assertIsInstance(offer.pop('id'), int)
     self.assertIsInstance(offer.pop('image'), (str, type(None)))
     self.assertIsInstance(offer.pop('location'), str)
     self.assertIsInstance(offer.pop('offer_status'), str)
     self.assertIsInstance(offer.pop('slug'), str)
-    self.assertIsInstance(offer.pop('started_at'), str)
+    self.assertIsInstance(offer.pop('started_at'), (str, type(None)))
     self.assertIsInstance(offer.pop('title'), str)
     self.assertIsInstance(offer.pop('url'), str)
     self.assertIsInstance(offer.pop('description'), str)

--- a/backend/apps/volontulo/tests/views/offers/commons.py
+++ b/backend/apps/volontulo/tests/views/offers/commons.py
@@ -24,6 +24,7 @@ class TestOffersCommons(object):
             organization=cls.organization,
             offer_status='published',
             recruitment_status='open',
+            finished_at=None,
         )
 
         cls.volunteer = UserProfileFactory.create(


### PR DESCRIPTION
__Description:__

In previous change (where I removed `action_status` field from database) I introduced a bug in how funciton `active` filters offers. This pull request aims to fix that.

Proper computed `action_status` property should fulfill this table:

| started_at \ finished_at | past     | not set | future  | 
| ------------------------ | -------- | ------- | ------- |
| past                     | finished | ongoing | ongoing |
| not set                  | finished | ongoing | ongoing |
| future                   | XXXXXXXX | future  | future  |

__New imports / dependencies:__

* N/A

__Unit Tests:__

All tests that use:
 * `TestOffersCommons` from `backend/apps/volontulo/tests/views/offers/commons.py` as to simply create active offer, we changes `finished_at` to `None`
* `test_offer_list_fields` from `backend/apps/volontulo/tests/common.py` as `started_at` and `finished_at` should be able to be also `None`/`null` 
