### PR TITLE
Default Facebook sharing metatags (fixes #803)

### DIFF
--- a/frontend/src/app/app.component.ts
+++ b/frontend/src/app/app.component.ts
@@ -3,7 +3,7 @@ import { Router, NavigationEnd } from '@angular/router';
 
 import { environment } from '../environments/environment';
 import { WindowService } from './window.service';
-
+import { MetatagsService } from './metatags.service';
 
 @Component({
   selector: 'volontulo-root',
@@ -14,6 +14,7 @@ export class AppComponent implements OnInit {
 
   constructor(
     @Inject(WindowService) private window: any,
+    private metatagsService: MetatagsService,
     private router: Router
   ) { }
 
@@ -21,6 +22,8 @@ export class AppComponent implements OnInit {
     this.window.ga('create', environment.googleAnalyticsAppID, 'auto');
     this.router.events.subscribe(event => {
       if (event instanceof NavigationEnd) {
+        this.metatagsService.setMeta();
+
         this.window.ga('set', 'page', event.urlAfterRedirects);
         this.window.ga('send', 'pageview');
       }

--- a/frontend/src/app/app.module.ts
+++ b/frontend/src/app/app.module.ts
@@ -2,7 +2,7 @@ import { ErrorHandler, NgModule, PLATFORM_ID, LOCALE_ID } from '@angular/core';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { BrowserModule } from '@angular/platform-browser';
 import { RouterModule, Routes } from '@angular/router';
-import { registerLocaleData } from '@angular/common';
+import { registerLocaleData, Location } from '@angular/common';
 import localePl from '@angular/common/locales/pl';
 import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
 import { CookieModule } from 'ngx-cookie';
@@ -237,6 +237,7 @@ registerLocaleData(localePl);
     LoggedOutGuard,
     ContactResolver,
     ContactService,
+    Location,
     { provide: LOCALE_ID, useValue: 'pl' },
     { provide: WindowService, useFactory: WindowFactory, deps: [PLATFORM_ID] },
     { provide: ErrorHandler, useFactory: ErrorHandlerFactory },

--- a/frontend/src/app/metatags.service.spec.ts
+++ b/frontend/src/app/metatags.service.spec.ts
@@ -1,10 +1,12 @@
 import { TestBed, inject } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
 
 import { MetatagsService } from './metatags.service';
 
 describe('MetatagsService', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
+      imports: [RouterTestingModule],
       providers: [MetatagsService]
     });
   });

--- a/frontend/src/app/metatags.service.ts
+++ b/frontend/src/app/metatags.service.ts
@@ -1,18 +1,36 @@
-import { Injectable } from '@angular/core';
+import { Location } from '@angular/common';
+import { Inject, Injectable } from '@angular/core';
 import { Meta, Title } from '@angular/platform-browser';
+import { ActivatedRouteSnapshot, RouterStateSnapshot } from '@angular/router';
+
+import { environment } from '../environments/environment';
 
 @Injectable()
 export class MetatagsService {
 
-  constructor(private MetaService: Meta, private TitleService: Title) { }
+  constructor(
+    private locationService: Location,
+    private metaService: Meta,
+    private titleService: Title
+  ) { }
 
-  public setMeta(title = 'Volontulo - Portal dla wolontariuszy', metatags = {}): void {
-    this.TitleService.setTitle(title);
+  public getCanonicalUrl(url: string): string {
+    return Location.joinWithSlash(environment.angularRoot, url);
+  }
 
+  public setMeta(title = 'Volontulo. Portal dla wolontariuszy', metatags = {}): void {
+    this.titleService.setTitle(title);
+
+    // set default tags, that will be orverwritten below:
+    this.metaService.updateTag({ name: 'og:url', content: this.getCanonicalUrl(this.locationService.path()) });
+    this.metaService.updateTag({ name: 'og:title', content: 'Volontulo. Portal dla wolontariuszy' });
+    this.metaService.updateTag({ name: 'og:description', content: 'Volontulo. Portal dla wolontariuszy'});
+    this.metaService.updateTag({ name: 'og:image', content: this.getCanonicalUrl('/assets/img/banner/volontulo_baner.png') });
+    this.metaService.updateTag({ name: 'fb:app_id', content: environment.fbAppID });
 
     Object.keys(metatags)
       .map((key) => ({name: key, content: metatags[key]}))
-      .forEach((metatag) => this.MetaService.updateTag(metatag))
+      .forEach((metatag) => this.metaService.updateTag(metatag));
   }
 
 }

--- a/frontend/src/environments/environment.dev.volontulo.pl.ts
+++ b/frontend/src/environments/environment.dev.volontulo.pl.ts
@@ -1,7 +1,9 @@
 export const environment = {
+  angularRoot: 'https://dev.volontulo.pl',
   apiRoot: 'https://dev.volontulo.pl/api',
   djangoRoot: 'https://dev.volontulo.pl/o',
   production: true,
   sentryDSN: 'https://b80a076c5dcd4f0cbdb6b7b677b89be1@sentry.io/227462',
   googleAnalyticsAppID: 'UA-114117196-3',
+  fbAppID: '1068510466661147',
 };

--- a/frontend/src/environments/environment.rc.volontulo.pl.ts
+++ b/frontend/src/environments/environment.rc.volontulo.pl.ts
@@ -1,7 +1,9 @@
 export const environment = {
+  angularRoot: 'https://rc.volontulo.pl',
   apiRoot: 'https://rc.volontulo.pl/api',
   djangoRoot: 'https://rc.volontulo.pl/o',
   production: true,
   sentryDSN: 'https://4ff2ebbd18b74200b07a3b0538259e5d@sentry.io/227463',
   googleAnalyticsAppID: 'UA-114117196-2',
+  fbAppID: '1870175263059925',
 };

--- a/frontend/src/environments/environment.ssr.ts
+++ b/frontend/src/environments/environment.ssr.ts
@@ -1,7 +1,9 @@
 export const environment = {
+  angularRoot: 'https://localhost:4200',
   apiRoot: 'http://backend:8000/api',
   djangoRoot: 'http://backend:8000/o',
   production: false,
   sentryDSN: null,
   googleAnalyticsAppID: null,
+  fbAppID: null,
 };

--- a/frontend/src/environments/environment.ts
+++ b/frontend/src/environments/environment.ts
@@ -4,9 +4,11 @@
 // The list of which env maps to which file can be found in `.angular-cli.json`.
 
 export const environment = {
+  angularRoot: 'http://localhost:4200',
   apiRoot: 'http://localhost:4200/api',
   djangoRoot: 'http://localhost:8000/o',
   production: false,
   sentryDSN: null,
   googleAnalyticsAppID: null,
+  fbAppID: null,
 };

--- a/frontend/src/environments/environment.volontulo.pl.ts
+++ b/frontend/src/environments/environment.volontulo.pl.ts
@@ -1,7 +1,9 @@
 export const environment = {
+  angularRoot: 'https://volontulo.pl',
   apiRoot: 'https://volontulo.pl/api',
   djangoRoot: 'https://volontulo.pl/o',
   production: true,
   sentryDSN: 'https://231fac114db44046b05ea775c9a4ada2@sentry.io/227464',
   googleAnalyticsAppID: 'UA-114117196-1',
+  fbAppID: '1973093309655849',
 };

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -2,7 +2,6 @@
 <html>
 <head>
   <meta charset="utf-8">
-  <title>Frontend</title>
   <base href="/">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/x-icon" href="favicon.ico?v1">


### PR DESCRIPTION
__Description:__

Default Facebook sharing metatags. Custom values (for offers and organizations will be handled in separate pull request)

__New imports / dependencies:__

* N/A

__Unit Tests:__

* N/A

__What tests do I need to run to validate this change:__

run SSR command (commented out in `docker-compose.yml`, it will take around 7 minut!!! for some reason) and check if rendered page contains facebook sharing metatags.