### PR TITLE
[597] Django API based logout endpoint unit test

### DIFF
--- a/backend/apps/volontulo/tests/views/api/test_logout_view.py
+++ b/backend/apps/volontulo/tests/views/api/test_logout_view.py
@@ -16,8 +16,8 @@ ENDPOINT_URL = reverse('api_logout')
 class TestLogoutViewAuthenticated(APITestCase, TestCase):
 
     def test_logout(self):
-        user = self.client.force_login(UserFactory())
-        res = self.client.post(ENDPOINT_URL, {user}, format='json')
+        self.client.force_login(UserFactory())
+        res = self.client.post(ENDPOINT_URL)
         self.assertEqual(res.status_code, 200)
 
 

--- a/backend/apps/volontulo/tests/views/api/test_logout_view.py
+++ b/backend/apps/volontulo/tests/views/api/test_logout_view.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+
+"""
+.. module:: test_login_view
+"""
+
+from django.test import TestCase
+from django.urls import reverse
+from rest_framework.test import APITestCase
+
+from apps.volontulo.factories import UserFactory
+
+ENDPOINT_URL = reverse('api_logout')
+
+
+class TestLogoutView(APITestCase, TestCase):
+
+    def test_logout(self):
+        user = self.client.force_login(UserFactory())
+        res = self.client.post(ENDPOINT_URL, {user}, format='json')
+        self.assertEqual(res.status_code, 200)

--- a/backend/apps/volontulo/tests/views/api/test_logout_view.py
+++ b/backend/apps/volontulo/tests/views/api/test_logout_view.py
@@ -13,9 +13,16 @@ from apps.volontulo.factories import UserFactory
 ENDPOINT_URL = reverse('api_logout')
 
 
-class TestLogoutView(APITestCase, TestCase):
+class TestLogoutViewAuthenticated(APITestCase, TestCase):
 
     def test_logout(self):
         user = self.client.force_login(UserFactory())
         res = self.client.post(ENDPOINT_URL, {user}, format='json')
         self.assertEqual(res.status_code, 200)
+
+
+class TestLogoutViewNotAuthenticated(APITestCase, TestCase):
+
+    def test_logout(self):
+        res = self.client.post(ENDPOINT_URL)
+        self.assertEqual(res.status_code, 400)


### PR DESCRIPTION
__Description:__

Adding unit test for api_logout endpoint

__New imports / dependencies:__

N/A

__Unit Tests:__

* `apps/volontulo/tests/views/api/test_logout_view.py

__What tests do I need to run to validate this change:__

N/A
